### PR TITLE
expand config_searchpath (e.g., to allow using ~/.config/)

### DIFF
--- a/click_configfile.py
+++ b/click_configfile.py
@@ -300,6 +300,7 @@ def generate_configfile_names(config_files, config_searchpath=None):
     for config_path in reversed(config_searchpath):
         for config_basename in reversed(config_files):
             config_fname = os.path.join(config_path, config_basename)
+            config_fname = os.path.expanduser(config_fname)
             if os.path.isfile(config_fname):
                 # MAYBE: yield os.path.normpath(config_fname)
                 yield config_fname


### PR DESCRIPTION
Allows a nicer way to locate user-specific configs.