### PR TITLE
Pass arguments to ConfigParser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,12 @@ The command implementation reads the configuraion file(s) by using the
 ``ConfigFileProcessor.read_config()`` method and stores it in the
 ``default_map`` of the ``context_settings``.
 
+If you need to refine the behaviour of the underlying ConfigParser then pass
+named arguments to ``read_config``, these will be passed on to the
+ConfigParser constructor. e.g.
+
+``ConfigFileProcessor.read_config(interpolation=ExtendedInterpolation())``
+
 That is only the first part of the problem. We have now a solution that allows
 us to read configuration files (and override the command options defaults)
 before the command-line parsing begins.

--- a/click_configfile.py
+++ b/click_configfile.py
@@ -382,10 +382,10 @@ class ConfigFileReader(object):
     # -- GENERIC PART:
     # Uses declarative specification from above (config_files, config_sections, ...)
     @classmethod
-    def read_config(cls):
+    def read_config(cls, **args):
         configfile_names = list(
             generate_configfile_names(cls.config_files, cls.config_searchpath))
-        parser = configparser.ConfigParser()
+        parser = configparser.ConfigParser(**args)
         parser.optionxform = str
         parser.read(configfile_names)
 

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -301,7 +301,7 @@ class TestCandidate2B(object):
             # -- POINT: CONTEXT_SETTINGS = dict(default_map=...)
             ConfigFileProcessorWithUnboundSection.read_config()
 
-        expected = "LookupError: No schema found for: section=unbound.section"
+        expected = "No schema found for: section=unbound.section"
         assert expected in str(e)
 
 

--- a/tests/unit/test_schema_description.py
+++ b/tests/unit/test_schema_description.py
@@ -162,5 +162,5 @@ class TestDecorators(object):
             class Hello(SectionSchema):
                 pass
 
-        expected = "ValueError: %r (expected: string, strings)" % bad_section_name
+        expected = "%r (expected: string, strings)" % bad_section_name
         assert expected in str(e)


### PR DESCRIPTION
This is a simple change to allow the passing of named arguments via ConfigFileProcessor.read_config() to the ConfigParser constructor.

A new test shows an example usage of allowing inline comments.
The documentation mentions this feature.

This would also fix #5 
